### PR TITLE
onError doesn't trigger because of the promise change in 5.0.1

### DIFF
--- a/modules/ImageHelper.js
+++ b/modules/ImageHelper.js
@@ -47,9 +47,7 @@ const ImageHelper = {
 
     loadImages(urls, options) {
         const promises = urls.map(url => this.loadImage(url, options));
-        return Promise.all(promises).catch((err) => {
-            console.warn(err.message);
-        });
+        return Promise.all(promises);
     },
 
     // preload without caring about the result


### PR DESCRIPTION
Remove promise catch as this prevents the "onError" of this module from triggering.